### PR TITLE
Add pollable state definitions into tcp state machine

### DIFF
--- a/TcpSocketOperationalSemantics.md
+++ b/TcpSocketOperationalSemantics.md
@@ -112,7 +112,7 @@ Most transitions are dependent on the result of the method. Legend:
 - Most state transitions shown above are driven by the caller and occur synchronously during the method invocations. There's four exceptions: transitions into `ConnectComplete`, `BindComplete` and `ListenComplete`, and `«connection terminated»` transition from `connected` to `closed`. This can happen when: the peer closed the connection, a network failure occurred, the connection timed out, etc.
 - 
 - While `shutdown` immediately closes the input and/or output streams associated with the socket, it does not affect the socket's own state as it just _initiates_ a shutdown. Only after the full shutdown sequence has been completed will the `«connection terminated»` transition be activated. (See previous item)
-- Calling a method from the wrong state returns `error(invalid-state)` and does not affect the state of the socket. A special case are the `finish-*` methods; those return `error(not-in-progress)` when the socket is not in the corresponding `*-in-progress` state.
+- Calling a method from the wrong state returns `error(invalid-state)` and does not affect the state of the socket. A special case are the `finish-*` methods; those return `error(not-in-progress)` when the socket is not in the corresponding `*-in-progress` or `*-complete` state.
 - This diagram only includes the methods that impact the socket's state. For an overview of all methods and their required states, see [tcp.wit](./wit/tcp.wit)
 - Client sockets returned by `accept()` are in immediately in the `connected` state.
 - A socket resource can be dropped in any state.

--- a/TcpSocketOperationalSemantics.md
+++ b/TcpSocketOperationalSemantics.md
@@ -69,7 +69,7 @@ stateDiagram-v2
     state "closed" as Closed
 
     [*] --> Unbound: create-tcp-socket()\n#ok
-    [*] --> Listening: accept()
+    [*] --> Connected: listen accept
 
     Unbound --> BindInProgress: start-bind()\n#ok
     Unbound --> Unbound: start-bind()\n#error
@@ -98,6 +98,8 @@ stateDiagram-v2
     ListenInProgress --> ListenComplete: «ready for finish-listen»
     ListenComplete --> Closed: finish-listen()\n#error(NOT would-block)
     ListenComplete --> Listening: finish-listen()\n#ok
+
+    Listening --> Listening: accept()
 ```
 
 Most transitions are dependent on the result of the method. Legend:

--- a/TcpSocketOperationalSemantics.md
+++ b/TcpSocketOperationalSemantics.md
@@ -69,7 +69,6 @@ stateDiagram-v2
     state "closed" as Closed
 
     [*] --> Unbound: create-tcp-socket()\n#ok
-    [*] --> Connected: listen accept
 
     Unbound --> BindInProgress: start-bind()\n#ok
     Unbound --> Unbound: start-bind()\n#error


### PR DESCRIPTION
This adds in just the pollable state definitions to the TCP states. We do this by defining the pollable state for each TCP state, and therefore this is what justifies the `complete` states (formerly `ready`).

It also fits quite well into the TCP state machine because the `would-block` transition is clearly defined as well.

Even without these states, I would strongly encourage a clear specification of the pollable resolution state for all states of the TCP machine in whatever form, this is just the way I found to do it.